### PR TITLE
Only allow alphanumeric characters for :project parameter

### DIFF
--- a/bin/asana2flowdock
+++ b/bin/asana2flowdock
@@ -127,7 +127,7 @@ Main {
             flow = Flowdock::Flow.new(
               :api_token => config.get(:flowdock, :token),
               :source    => "asana",
-              :project   => project.name,
+              :project   => project.name.gsub(/[^0-9a-z _\-]/i, ''),
               :from      => from
             )
 


### PR DESCRIPTION
Also allow spaces, dashes and underscores.

When an Asana project name had non-alphanumeric characters (e.g. an apostrophe), asana2flowdock would not forward messages. This should fix that case.
